### PR TITLE
update: change default pb version to 0.22.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.6
 
 # You can change Pocketbase version here
 ARG POCKETBASE_VERSION=0.22.20
-ENV POCKETBASE_VERSION ${POCKETBASE_VERSION}
+ENV POCKETBASE_VERSION=${POCKETBASE_VERSION}
 
 # Install the dependencies
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine:3.6
 
 # You can change Pocketbase version here
-ARG POCKETBASE_VERSION=0.22.4
+ARG POCKETBASE_VERSION=0.22.20
 ENV POCKETBASE_VERSION ${POCKETBASE_VERSION}
 
 # Install the dependencies


### PR DESCRIPTION
## Proposed changes:
1. Change default pocketbase version to latest release, moving from 0.22.4 to 0.22.20. Latest release info: https://github.com/pocketbase/pocketbase/releases 
2. Fix for warning when deploying: ```remote:  1 warning found (use --debug to expand):
remote:  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 7)```



---

Love the project, running it out now for some small projects. Thanks for publishing the project!

Realized there have been a few releases on pocketbase and updated my default pocketbase version to the latest release locally. 