### PR TITLE
Remove redundant health check route

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -1,5 +1,3 @@
 WAIT=10
 ATTEMPTS=3
-/api/health HTTP/1.1
-Host: pocketbase
-User-Agent: Dokku/1.0
+/api/health API is healthy

--- a/pb_hooks/health.pb.js
+++ b/pb_hooks/health.pb.js
@@ -1,3 +1,0 @@
-routerAdd("GET", "/api/health", (c) => {
-  return c.json(200, { "status": "ok" });
-});


### PR DESCRIPTION
  Summary

  Fixes deployment failures caused by duplicate route registration for /api/health. PocketBase has included a built-in /api/health endpoint since v0.10.0, making the custom hook redundant and causing route
  conflicts.

  Problem

  When deploying to Dokku, the application would panic on startup with:
  panic: pattern "GET /api/health" conflicts with pattern "GET /api/health"

  This occurred because:
  1. PocketBase already provides /api/health (since v0.10.0)
  2. The custom pb_hooks/health.pb.js was attempting to register the same route
  3. Go 1.22+ enforces stricter route conflict detection, causing the panic

  Changes

  - Deleted pb_hooks/health.pb.js: Removed custom health endpoint that duplicated built-in functionality
  - Updated CHECKS: Simplified health check syntax to verify the built-in endpoint returns "API is healthy" in the response

  Before:
  /api/health HTTP/1.1
  Host: pocketbase
  User-Agent: Dokku/1.0

  After:
  /api/health API is healthy

  Result

  - ✅ Deployment completes successfully
  - ✅ Health checks pass
  - ✅ Uses PocketBase's built-in, maintained endpoint instead of custom code